### PR TITLE
Add comment about https

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # twofactor_webauthn
 Roundcube plugin for FIDO2/WebAuthn 2-factor authentication
+
+To use the plugin you need a valid https connection to your roundcube instance otherwise nothing will happens when click the buttons ! (Firefox 84.0)


### PR DESCRIPTION
Without an https connection nothing happens in the webui.
Tested in firefox 84.0.2 with haproxy as reserve proxy and ssl offloading.