### PR TITLE
Fix login redirect when use_secure_urls == true

### DIFF
--- a/twofactor_webauthn.php
+++ b/twofactor_webauthn.php
@@ -193,11 +193,11 @@ class twofactor_webauthn extends rcube_plugin {
     if ($webauthn->authenticate($response, $config['keys'])) {
       $_SESSION['twofactor_webauthn_checked'] = 1;
       $rcmail->output->show_message($this->gettext('authentication_succeeded'), 'confirmation');
-      $rcmail->output->command('plugin.twofactor_webauthn_redirect', [ 'delay' => 1 ]);
+      $rcmail->output->command('plugin.twofactor_webauthn_redirect', [ 'url' => $rcmail->url(['_task'=>'mail'], true, false, true), 'delay' => 1 ]);
     }
     else {
       $rcmail->output->show_message($this->gettext('authentication_failed'), 'warning');
-      $rcmail->output->command('plugin.twofactor_webauthn_redirect', [ 'delay' => 10 ]);
+      $rcmail->output->command('plugin.twofactor_webauthn_redirect', [ 'url' => $rcmail->url([], true), 'delay' => 10 ]);
     }
   }
 

--- a/twofactor_webauthn_form.js
+++ b/twofactor_webauthn_form.js
@@ -29,8 +29,8 @@ function twofactor_webauthn_auth() {
 }
 
 function twofactor_webauthn_redirect(data) {
-  if (data.delay) tw_timeout = setTimeout("location = './';", data.delay*1000);
-  else location = './';
+  if (data.delay) tw_timeout = setTimeout(`location = '${data.url}';`, data.delay*1000);
+  else location = data.url;
 }
 
 // WebAuthn support by David Earl - https://github.com/davidearl/webauthn/


### PR DESCRIPTION
When the `use_secure_urls` config setting is `true`, a successful login redirects to roundcubemail's root path without the url token. This (eventually) results in the ominous error below. This small update should fix this.

### REQUEST CHECK FAILED

For your protection, access to this resource is secured against CSRF.  
If you see this, you probably didn't log out before leaving the web application.

Human interaction is now required to continue.
